### PR TITLE
Cleaning up ignored code after `end.`

### DIFF
--- a/logtreeview.pas
+++ b/logtreeview.pas
@@ -271,22 +271,3 @@ end;
 initialization
   {$i logimages.lrs}
 end.
-
-.Parent.Expanded:=True;
-  FLastNode.GetFirstChild;
-  //todo: optimize painting
-  FLastNode.ImageIndex:=AMsg.MsgType;
-  FLastNode.SelectedIndex:=AMsg.MsgType;
-end;
-
-procedure TLogTreeView.Clear;
-begin
-  Items.Clear;
-  FLastNode:=nil;
-  FParentNode:=nil;
-end;
-
-initialization
-  {$i logimages.lrs}
-end.
-


### PR DESCRIPTION
This PR cleans up the unused repetition of code after `end.` (with a dot). It is the end of the unit, and the compiler does not read after it anyway.